### PR TITLE
fix call to backtrace

### DIFF
--- a/cuBQL/common/common.h
+++ b/cuBQL/common/common.h
@@ -137,7 +137,7 @@ namespace cuBQL {
         throw std::runtime_error(str);
 #else
 #ifndef NDEBUG
-      std::string bt = ::detail::backtrace();
+      std::string bt = backtrace();
       fprintf(stderr,"%s\n",bt.c_str());
 #endif
       raise(SIGINT);


### PR DESCRIPTION
was in the wrong namespace