### PR TITLE
Adding a memory resource

### DIFF
--- a/cuBQL/common/common.h
+++ b/cuBQL/common/common.h
@@ -137,7 +137,7 @@ namespace cuBQL {
         throw std::runtime_error(str);
 #else
 #ifndef NDEBUG
-      std::string bt = ::detail::backtrace();
+      std::string bt = backtrace();
       fprintf(stderr,"%s\n",bt.c_str());
 #endif
       raise(SIGINT);

--- a/cuBQL/impl/builder_common.h
+++ b/cuBQL/impl/builder_common.h
@@ -24,12 +24,12 @@ namespace cuBQL {
   namespace gpuBuilder_impl {
 
     template<typename T, typename count_t>
-    inline void _ALLOC(T *&ptr, count_t count, cudaStream_t s)
-    { CUBQL_CUDA_CALL(MallocAsync((void**)&ptr,count*sizeof(T),s)); }
+    inline void _ALLOC(T *&ptr, count_t count, cudaStream_t s, GpuMemoryResource& mem_resource)
+    { CUBQL_CUDA_CHECK(mem_resource.malloc((void**)&ptr,count*sizeof(T),s)); }
     
     template<typename T>
-    inline void _FREE(T *&ptr, cudaStream_t s)
-    { CUBQL_CUDA_CALL(FreeAsync((void*)ptr,s)); ptr = 0; }
+    inline void _FREE(T *&ptr, cudaStream_t s, GpuMemoryResource& mem_resource)
+    { CUBQL_CUDA_CHECK(mem_resource.free((void*)ptr,s)); ptr = 0; }
     
     typedef enum : int8_t { OPEN_BRANCH, OPEN_NODE, DONE_NODE } NodeState;
     

--- a/cuBQL/impl/instantiate_builders.cu
+++ b/cuBQL/impl/instantiate_builders.cu
@@ -23,27 +23,31 @@ namespace cuBQL {
                            const box3f *boxes,
                            uint32_t     numBoxes,
                            BuildConfig  buildConfig,
-                           cudaStream_t s);
+                           cudaStream_t s,
+                           GpuMemoryResource& mem_resource);
   template void gpuBuilder(WideBVH<4>   &bvh,
                            const box3f *boxes,
                            uint32_t     numBoxes,
                            BuildConfig  buildConfig,
-                           cudaStream_t s);
+                           cudaStream_t s,
+                           GpuMemoryResource& mem_resource);
   template void gpuBuilder(WideBVH<8>   &bvh,
                            const box3f *boxes,
                            uint32_t     numBoxes,
                            BuildConfig  buildConfig,
-                           cudaStream_t s);
+                           cudaStream_t s,
+                           GpuMemoryResource& mem_resource);
   template void gpuBuilder(WideBVH<16>   &bvh,
                            const box3f *boxes,
                            uint32_t     numBoxes,
                            BuildConfig  buildConfig,
-                           cudaStream_t s);
+                           cudaStream_t s,
+                           GpuMemoryResource& mem_resource);
 
-  template void free(WideBVH<2>  &bvh, cudaStream_t s);
-  template void free(WideBVH<4>  &bvh, cudaStream_t s);
-  template void free(WideBVH<8>  &bvh, cudaStream_t s);
-  template void free(WideBVH<16> &bvh, cudaStream_t s);
+  template void free(WideBVH<2>  &bvh, cudaStream_t s, GpuMemoryResource& mem_resource);
+  template void free(WideBVH<4>  &bvh, cudaStream_t s, GpuMemoryResource& mem_resource);
+  template void free(WideBVH<8>  &bvh, cudaStream_t s, GpuMemoryResource& mem_resource);
+  template void free(WideBVH<16> &bvh, cudaStream_t s, GpuMemoryResource& mem_resource);
   
   template float computeSAH(const WideBVH<2>  &bvh);
   template float computeSAH(const WideBVH<4>  &bvh);


### PR DESCRIPTION
Force all the calls to malloc/free to go through a memory resource object.
This can be used to use cudaMalloc instead of cudaMallocAsync on platforms where the later is not supported
Or use a memory pool...